### PR TITLE
Add ``Download yarn.lock's dependencies'' script

### DIFF
--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+yarn_lock_file=${1:?"Please specify path to \`\`yarn.lock'' file to \
+extract dependencies from."}
+date=$(date --utc --rfc-3339=seconds | sed \
+    -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
+download_prefix=${2:-./dependencies/${date}}
+
+mkdir --parents ${download_prefix}
+
+sed --silent \
+    --expression "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
+    ${yarn_lock_file} | wget --directory-prefix=${download_prefix} \
+    --verbose --input-file=- && \
+    echo "The dependencies were successfully downloaded into the" \
+    "\`\`${download_prefix}'' directory."


### PR DESCRIPTION
This PR adds shell script downloading all dependencies for a project
managed by [Yarn][1]. Downloaded tarballs may be used as content
for an offline package repository.

The script extracts dependency links from specified \`\`yarn.lock'' file
and downloads gzip'ed tarballs into specified or default directory.

Script usage:

```sh
$ ./download_dependencies.sh yarn.lock dir
```

\`\`yarn.lock'' is path to a project's yarn.lock file. \`\`dir'' is target
directory where downloaded tarballs will be stored. If the latter is
omitted, this script uses 'dependencies/{current date/time}' directory
by default.

I am not a specialist in JavaScript and related technology, therefore
this script may not solve the problem† perfectly.

† To download dependencies for a project managed by Yarn, and then
"use" the dependencies to allow `yarn install --offline` on host not
connected to the Internet (*offline*).

[1]: https://yarnpkg.com/
