### PR TITLE
Add ``Offline upgrade'' scripts

### DIFF
--- a/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+date=$(date --utc --rfc-3339=seconds | \
+    sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
+download_prefix=./databases/${date}
+
+mkdir --parents ${download_prefix}
+
+arch=x86_64
+mirror=https://mirrors.edge.kernel.org/\
+archlinux
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/core/os/${arch}/core.db
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/community/os/${arch}/community.db
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/extra/os/${arch}/extra.db
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/multilib/os/${arch}/multilib.db

--- a/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+date=$(date --utc --rfc-3339=seconds | \
+    sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
+download_prefix=./databases/${date}
+
+mkdir --parents ${download_prefix}
+
+arch=x86_64
+mirror=http://repo.msys2.org/msys
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/${arch}/msys.db{,.sig}
+gpg --verify ${download_prefix}/msys.db.sig 2>&1 | head --lines=4 | \
+    sed --expression \
+    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+    xargs -0 echo -e
+mirror=http://repo.msys2.org/mingw
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/${arch}/mingw64.db{,.sig}
+gpg --verify ${download_prefix}/mingw64.db.sig 2>&1 | head --lines=4 | \
+    sed --expression \
+    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+    xargs -0 echo -e
+arch=i686
+wget --directory-prefix=${download_prefix} \
+    ${mirror}/${arch}/mingw32.db{,.sig}
+gpg --verify ${download_prefix}/mingw32.db.sig 2>&1 | head --lines=4 | \
+    sed --expression \
+    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+    xargs -0 echo -e

--- a/Arch_Linux/Offline_Upgrade/download_packages.sh
+++ b/Arch_Linux/Offline_Upgrade/download_packages.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+tag=${1:-"undefined"}
+date=$(date --utc --rfc-3339=seconds | \
+    sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
+download_prefix=./packages/${date}_${tag}
+
+mkdir --parents ${download_prefix}
+
+echo $(cat packages_list | wc --lines) "file(s) to download".
+wget --directory-prefix=${download_prefix} --verbose \
+    --input-file=packages_list


### PR DESCRIPTION
This PR adds two scripts which may be used to upgrade a system
managed by the \`\`pacman'' package manager (therefore, the scripts may be
used to upgrade Arch Linux hosts or msys2 environments). The primary
target for the scripts is an **offline** system (one not connected to the
Internet :skull:).

The \`\`download_databases_arch_linux.sh'' script downloads package
databases for Arch Linux system. Currently it checks for Arch Linux
\`\`core'', \`\`community'', \`\`extra'' and \`\`multilib'' repositories.  The
databases must be placed into '/var/lib/pacman/sync' directory on
offline host.

The \`\`download_databases_msys2.sh'' script downloads package databases
for msys2 environments, using \`\`msys'' and \`\`mingw'' (32 and 64)
repositories.

The \`\`download_packages.sh'' script downloads packages using URLs
specified in 'packages_list' file. Downloaded tarballs must be placed
into '/var/cache/pacman/pkg' directory on offline host.
