### PR TITLE
Improve scripts for offline updating

### DIFF
--- a/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
@@ -1,4 +1,8 @@
 #! /bin/sh
+# Copyright (c) 2018, Ruslan Garipov.
+# Contacts: <ruslanngaripov@gmail.com>.
+# License: MIT License (https://opensource.org/licenses/MIT).
+# Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
 date=$(date --utc --rfc-3339=seconds | \
     sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")

--- a/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
@@ -1,4 +1,8 @@
 #! /bin/sh
+# Copyright (c) 2018, Ruslan Garipov.
+# Contacts: <ruslanngaripov@gmail.com>.
+# License: MIT License (https://opensource.org/licenses/MIT).
+# Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
 date=$(date --utc --rfc-3339=seconds | \
     sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")

--- a/Arch_Linux/Offline_Upgrade/download_packages.sh
+++ b/Arch_Linux/Offline_Upgrade/download_packages.sh
@@ -1,12 +1,26 @@
-#! /bin/bash
+#! /bin/sh
+# Copyright (c) 2018, Ruslan Garipov.
+# Contacts: <ruslanngaripov@gmail.com>.
+# License: MIT License (https://opensource.org/licenses/MIT).
+# Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
 tag=${1:-"undefined"}
+pack_list=${2:-"package_list"}
+
+if test -f ${pack_list}
+then
 date=$(date --utc --rfc-3339=seconds | \
     sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
 download_prefix=./packages/${date}_${tag}
 
+if ! test -e ${download_prefix}
+then
 mkdir --parents ${download_prefix}
+fi
 
-echo $(cat packages_list | wc --lines) "file(s) to download".
+echo $(cat ${pack_list} | wc --lines) "file(s) to download".
 wget --directory-prefix=${download_prefix} --verbose \
-    --input-file=packages_list
+    --input-file=${pack_list}
+else
+echo "File \`\`${pack_list}'' does not exist."
+fi

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -1,4 +1,8 @@
 #! /bin/sh
+# Copyright (c) 2018, Ruslan Garipov.
+# Contacts: <ruslanngaripov@gmail.com>.
+# License: MIT License (https://opensource.org/licenses/MIT).
+# Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
 yarn_lock_file=${1:?"Please specify path to \`\`yarn.lock'' file to \
 extract dependencies from."}


### PR DESCRIPTION
I added some small improvements to \`\`download packages'' script (targeting to system which are managed by the \`\`pacman'').

I also added headers in some scripts.

Hope the \`\`download_packages.sh'' will work under `sh` -- I currently have only `bash` available :pray: