### PR TITLE
Use `getopts` in script getting yarn dependencies

### DIFF
--- a/JavaScript/Yarn/README.md
+++ b/JavaScript/Yarn/README.md
@@ -1,0 +1,33 @@
+# Download dependencies specified in \`\`yarn.lock''
+
+## Description
+
+'download\_dependencies.sh' script extracts links to all package
+tarballs specified in a \`\`yarn.lock'' [file][1] and downloads the
+packages to the specified directory.
+
+## Usage
+
+```sh
+./download_dependencies.sh -f <yarn.lock file> -p <download prefix>
+```
+
+or, for script synopsis:
+
+```sh
+./download_dependencies.sh -h
+```
+
+Using the `-f` option user specifies path to the source 'yarn.lock'
+file. This script extracts links to package tarballs from that file, and
+downloads the tarballs to directory defined by the `-p` option. If the
+directory specified by the `-p` option does not exist, this script
+creates it.
+
+## Requirements
+
+This script currently uses GNU \`\`wget'' tools.
+
+This script is compatible with `sh(1)` shell.
+
+[1]: https://yarnpkg.com/en/docs/yarn-lock

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -4,17 +4,55 @@
 # License: MIT License (https://opensource.org/licenses/MIT).
 # Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
-yarn_lock_file=${1:?"Please specify path to \`\`yarn.lock'' file to \
-extract dependencies from."}
-date=$(date --utc --rfc-3339=seconds | sed \
-    -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
-download_prefix=${2:-./dependencies/${date}}
+PrintUsage()
+{
+  echo "Usage: download_dependencies.sh [-f <'yarn.lock' file>]"
+  echo "                                [-p <download location>]"
+  echo "                                [-h]"
+  exit 0
+}
 
-mkdir --parents ${download_prefix}
+if test 0 -eq $#
+then
+  PrintUsage
+fi
+while getopts ":hf:p:" opt
+do
+  case ${opt} in
+    f)
+      yarn_lock_file=${OPTARG};;
+    h)
+      PrintUsage;;
+    p)
+      download_prefix=${OPTARG};;
+    \?)
+      echo "\`\`${OPTARG}'' is an unknown option." 1>&2
+      exit 1;;
+    :)
+      echo "\`\`${OPTARG}'' requires an argument." 1>&2
+      exit 1;;
+  esac
+done
 
-sed --silent \
-    --expression "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
-    ${yarn_lock_file} | wget --directory-prefix=${download_prefix} \
-    --verbose --input-file=- && \
+if test -z ${yarn_lock_file}
+then
+  echo "Please use \`\`-f'' option to specify location of 'yarn.lock' file."
+  echo "'${0} -h' for more information."
+  exit 1;
+fi
+if test -z ${download_prefix}
+then
+  echo "Please use \`\`-p'' option to specify download (target) location."
+  echo "'${0} -h' for more information."
+  exit 1;
+fi
+
+if ! test -e ${download_prefix}
+then
+  mkdir -p ${download_prefix}
+fi
+
+sed -n -e "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
+    ${yarn_lock_file} | wget -P=${download_prefix} -v -i=- && \
     echo "The dependencies were successfully downloaded into the" \
     "\`\`${download_prefix}'' directory."


### PR DESCRIPTION
This patch is the first part of coming changes. I introduced the `getopts` (see sh(1)) into the script and make it compatible with sh(1).

*A replacement for GNU \`\`wget'' is required, I believe.*