### PR TITLE
Improve script getting yarn dependencies

### DIFF
--- a/JavaScript/Yarn/README.md
+++ b/JavaScript/Yarn/README.md
@@ -26,8 +26,10 @@ creates it.
 
 ## Requirements
 
-This script currently uses GNU \`\`wget'' tools.
+On [FreeBSD][2] this script uses fetch(1). On other systems it uses GNU
+wget(1).
 
-This script is compatible with `sh(1)` shell.
+This script is compatible with sh(1) shell.
 
-[1]: https://yarnpkg.com/en/docs/yarn-lock
+[1]: https://yarnpkg.com/en/docs/yarn-lock/
+[2]: https://www.FreeBSD.org/

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -19,17 +19,12 @@ fi
 while getopts ":hf:p:" opt
 do
   case ${opt} in
-    f)
-      yarn_lock_file=${OPTARG};;
-    h)
-      PrintUsage;;
-    p)
-      download_prefix=${OPTARG};;
-    \?)
-      echo "\`\`${OPTARG}'' is an unknown option." 1>&2
+    f) yarn_lock_file=${OPTARG};;
+    h) PrintUsage;;
+    p) download_prefix=${OPTARG};;
+    \?) echo "\`\`${OPTARG}'' is an unknown option." 1>&2
       exit 1;;
-    :)
-      echo "\`\`${OPTARG}'' requires an argument." 1>&2
+    :) echo "\`\`${OPTARG}'' requires an argument." 1>&2
       exit 1;;
   esac
 done
@@ -38,13 +33,13 @@ if test -z ${yarn_lock_file}
 then
   echo "Please use \`\`-f'' option to specify location of 'yarn.lock' file."
   echo "'${0} -h' for more information."
-  exit 1;
+  exit 1
 fi
 if test -z ${download_prefix}
 then
   echo "Please use \`\`-p'' option to specify download (target) location."
   echo "'${0} -h' for more information."
-  exit 1;
+  exit 1
 fi
 
 if ! test -e ${download_prefix}
@@ -52,7 +47,16 @@ then
   mkdir -p ${download_prefix}
 fi
 
-sed -n -e "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
-    ${yarn_lock_file} | wget -P=${download_prefix} -v -i=- && \
-    echo "The dependencies were successfully downloaded into the" \
-    "\`\`${download_prefix}'' directory."
+if test -n "$(fetch 2>&1 | grep -e 'usage')"
+then
+  # We have to use extended (modern) regular expressions and not BRE, because we
+  # need branches, and BRE does not have it (``|'').
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\//;s/(\/{1})/\\\\\1/gp")
+  sed -n -e "/^ *resolved /\
+s/^ *resolved \{1,\}\"\(.\{1,\}\/\(.\{1,\}\)#.\{1,\}\)\"$/\
+fetch -o ${download_prefix}\2 \1/p" ${yarn_lock_file} | /bin/sh -s
+else
+  sed -n -e "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
+      ${yarn_lock_file} | wget -P ${download_prefix} -v -i -
+fi


### PR DESCRIPTION
This commit makes ``download_dependencies.sh'' script compatible with
[FreeBSD][1] :smiling_imp: by using its base system's [fetch(1)][2]. Other systems :penguin: still
use GNU [wget(1)][3].

See also #7.

[1]: https://www.FreeBSD.org/
[2]: https://www.freebsd.org/cgi/man.cgi?query=fetch&sektion=1&format=ascii
[3]: https://jlk.fjfi.cvut.cz/arch/manpages/man/extra/wget/wget.1.en
