### PR TITLE
Use `getopts` in scripts for offline upgrades

### DIFF
--- a/Arch_Linux/Offline_Upgrade/README.md
+++ b/Arch_Linux/Offline_Upgrade/README.md
@@ -1,0 +1,107 @@
+# Download \`\`pacman'' databases and packages
+
+## Description
+
+This directory provides shell scripts that allow to upgrade
+\`\`pacman''-based systems like [Arch Linux][2] distribution and
+[MSYS2][3] environment, while their hosts are offline (lack the Internet
+connection).
+
+## Usage
+
+First, you must download package databases using a script targetting
+your platform, running it on a host connected to the Internet:
+
+- \`\`download\_databases\_arch\_linux.sh'' if you are to upgrade Arch
+Linux host;
+- \`\`download\_databases\_msys2.sh'' if you are to upgrade MSYS2
+environment.
+
+```sh
+./download_databases_arch_linux.sh -p <download prefix> [-t]
+```
+
+or
+
+```sh
+./download_databases_msys2.sh -p <download prefix> [-t]
+```
+
+or, for scripts synopsis:
+
+```sh
+./download_databases_arch_linux.sh -h
+./download_databases_msys2.sh -h
+```
+
+Those scripts downloads package databases (\*.db files) to directory
+defined by the `-p` option. If the directory specified by the `-p`
+option does not exist, the scipts create it. If you specified `-t`
+option, the scripts create subdirectory in directory defined by the
+`-p`. That "tagged" subdirectory has name consisting of the current
+date/time information.
+
+MSYS2 targeting script also downloads GPG signature files. If executing
+host has [GNU GPG][4] installed, \`\`download\_databases\_msys2.sh''
+script verifies the downloaded databases using *sig* files.
+
+After you have downloaded package databases, you must transfer all the
+\`\`\*.db'' files (for MSYS2 also all the \`\`\*.db.sig'' files) to
+\`\`/var/lib/pacman/sync/'' directory on your target (offline) host.
+This way you emulate executing of `pacman -Sy` on your host.
+
+Next, run "system upgrade" on your offline host using the following
+command:
+
+```sh
+pacman -Sup --noconfirm
+```
+
+This gives you direct links to outdated packages basing on your
+\`\`/etc/pacman.d/mirrorlist'' file and new package databases. To save
+those link list into a file you may use something like this:
+
+```sh
+pacman -Sup | sed -n -e "/https:\/\//p" > package_list
+```
+
+Now, you must transfer package list file back to host connected to the
+Internet, and run \`\`download\_packages.sh'' scirpt:
+
+```sh
+./download_packages.sh -f <package list file> -p <download prefix> [-t]
+```
+
+or, for script synopsis:
+
+```sh
+./download_databases.sh -h
+```
+
+Using the `-f` option you specify path to file containg links to
+required packages (the one you created on your offline host). This
+scirpt downloads packages to directory defined by the `-p` option. If
+the directory specified by the `-p` option does not exist, this script
+creates it. If you specified `-t` option, the scripts create
+subdirectory in directory defined by the `-p`. That "tagged"
+subdirectory has name consisting of the current date/time information.
+
+Transfer all \`\`\*.pkg.tar.xz'' files you have downloaded to
+\`\`/var/cache/pacman/pkg/'' directory on your target (offline) host,
+and run system upgrade:
+
+```sh
+pacman -Su
+```
+
+## Requirements
+
+On [FreeBSD][1] this script uses fetch(1). On other systems it uses GNU
+wget(1). MSYS2-targeting script may use [GNU GPG][4] toolset.
+
+This script is compatible with sh(1) shell.
+
+[1]: https://freebsd.org/
+[2]: https://www.archlinux.org/
+[3]: https://www.msys2.org/
+[4]: https://gnupg.org/

--- a/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
@@ -4,20 +4,62 @@
 # License: MIT License (https://opensource.org/licenses/MIT).
 # Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
-date=$(date --utc --rfc-3339=seconds | \
-    sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
-download_prefix=./databases/${date}
+PrintUsage()
+{
+  echo "Usage: download_databases.sh [-p <download location>] [-t]"
+  echo "                             [-h]"
+  exit 0;
+}
 
-mkdir --parents ${download_prefix}
+if test 0 -eq $#
+then
+  PrintUsage
+fi
+while getopts ":hp:t" opt
+do
+  case ${opt} in
+    h) PrintUsage;;
+    p) download_prefix=${OPTARG};;
+    t) date=$(date -u "+%Y-%m-%d_%H_%M_%S_%Z")
+      tag=${date};;
+    \?) echo "\`\`${OPTARG}'' is an unknown option." 1>&2
+      exit 1;;
+    :) echo "\`\`${OPTARG}'' requires an argument." 1>&2
+      exit 1;;
+  esac
+done
+
+if test -z ${download_prefix}
+then
+  echo "Please use \`\`-p'' option to specify download (target) location."
+  echo "'${0} -h' for more information."
+  exit 1
+elif test -n ${tag}
+then
+  # We have to use extended (modern) regular expressions and not BRE, because we
+  # need branches, and BRE does not have it (``|'').
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+fi
+download_prefix=$(echo "${download_prefix}" | sed -n -E \
+    -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+
+if ! test -e ${download_prefix}
+then
+  mkdir -p ${download_prefix}
+fi
 
 arch=x86_64
-mirror=https://mirrors.edge.kernel.org/\
-archlinux
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/core/os/${arch}/core.db
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/community/os/${arch}/community.db
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/extra/os/${arch}/extra.db
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/multilib/os/${arch}/multilib.db
+mirror=https://mirrors.edge.kernel.org/archlinux
+if test "$(fetch 2>&1 | grep -e 'usage')"
+then
+  fetch -o ${download_prefix} ${mirror}/core/os/${arch}/core.db
+  fetch -o ${download_prefix} ${mirror}/community/os/${arch}/community.db
+  fetch -o ${download_prefix} ${mirror}/extra/os/${arch}/extra.db
+  fetch -o ${download_prefix} ${mirror}/multilib/os/${arch}/multilib.db
+else
+  wget -v -P ${download_prefix} ${mirror}/core/os/${arch}/core.db
+  wget -v -P ${download_prefix} ${mirror}/community/os/${arch}/community.db
+  wget -v -P ${download_prefix} ${mirror}/extra/os/${arch}/extra.db
+  wget -v -P ${download_prefix} ${mirror}/multilib/os/${arch}/multilib.db
+fi

--- a/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
@@ -4,31 +4,96 @@
 # License: MIT License (https://opensource.org/licenses/MIT).
 # Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
 
-date=$(date --utc --rfc-3339=seconds | \
-    sed -e "s/\(\+\)00:00/\105:00/; s/ /_/g; s/\:/_/g")
-download_prefix=./databases/${date}
+PrintUsage()
+{
+  echo "Usage: download_databases.sh [-p <download location>] [-t]"
+  echo "                             [-h]"
+  exit 0;
+}
 
-mkdir --parents ${download_prefix}
+if test 0 -eq $#
+then
+  PrintUsage
+fi
+while getopts ":hp:t" opt
+do
+  case ${opt} in
+    h) PrintUsage;;
+    p) download_prefix=${OPTARG};;
+    t) date=$(date -u "+%Y-%m-%d_%H_%M_%S_%Z")
+      tag=${date};;
+    \?) echo "\`\`${OPTARG}'' is an unknown option." 1>&2
+      exit 1;;
+    :) echo "\`\`${OPTARG}'' requires an argument." 1>&2
+      exit 1;;
+  esac
+done
+
+if test -z ${download_prefix}
+then
+  echo "Please use \`\`-p'' option to specify download (target) location."
+  echo "'${0} -h' for more information."
+  exit 1
+elif test -n ${tag}
+then
+  # We have to use extended (modern) regular expressions and not BRE, because we
+  # need branches, and BRE does not have it (``|'').
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+fi
+download_prefix=$(echo "${download_prefix}" | sed -n -E \
+    -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+
+if ! test -e ${download_prefix}
+then
+  mkdir -p ${download_prefix}
+fi
 
 arch=x86_64
 mirror=http://repo.msys2.org/msys
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/${arch}/msys.db{,.sig}
-gpg --verify ${download_prefix}/msys.db.sig 2>&1 | head --lines=4 | \
-    sed --expression \
-    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
-    xargs -0 echo -e
+fetch_exists="$(fetch 2>&1 | grep -e 'usage')"
+gpg_exists="$(gpg -h 2>&1 | grep -e 'Syntax')"
+if test "${fetch_exists}"
+then
+  fetch -o ${download_prefix} ${mirror}/${arch}/msys.db \
+      ${mirror}/${arch}/msys.db.sig
+else
+  wget -v -P ${download_prefix} ${mirror}/${arch}/msys.db \
+      ${mirror}/${arch}/msys.db.sig
+fi
+if test "${gpg_exists}"
+then
+  gpg --verify ${download_prefix}/msys.db.sig 2>&1 | head --lines=4 | \
+      sed -e 's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+      xargs -0 echo -e
+fi
 mirror=http://repo.msys2.org/mingw
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/${arch}/mingw64.db{,.sig}
-gpg --verify ${download_prefix}/mingw64.db.sig 2>&1 | head --lines=4 | \
-    sed --expression \
-    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
-    xargs -0 echo -e
+if test "${fetch_exists}"
+then
+  fetch -o ${download_prefix} ${mirror}/${arch}/mingw64.db \
+      ${mirror}/${arch}/mingw64.db.sig
+else
+  wget -v -P ${download_prefix} ${mirror}/${arch}/mingw64.db \
+      ${mirror}/${arch}/mingw64.db.sig
+fi
+if test "${gpg_exists}"
+then
+  gpg --verify ${download_prefix}/mingw64.db.sig 2>&1 | head --lines=4 | \
+      sed -e 's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+      xargs -0 echo -e
+fi
 arch=i686
-wget --directory-prefix=${download_prefix} \
-    ${mirror}/${arch}/mingw32.db{,.sig}
-gpg --verify ${download_prefix}/mingw32.db.sig 2>&1 | head --lines=4 | \
-    sed --expression \
-    's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
-    xargs -0 echo -e
+if test "${fetch_exists}"
+then
+  fetch -o ${download_prefix} ${mirror}/${arch}/mingw32.db \
+      ${mirror}/${arch}/mingw32.db.sig
+else
+  wget -v -P ${download_prefix} ${mirror}/${arch}/mingw32.db \
+      ${mirror}/${arch}/mingw32.db.sig
+fi
+if test "${gpg_exists}"
+then
+  gpg --verify ${download_prefix}/mingw32.db.sig 2>&1 | head --lines=4 | \
+      sed -e 's/\(.*\)\(Good signature\)\(.*\)/\1\\x1b[1;31m\2\\x1b[0m\3/' | \
+      xargs -0 echo -e
+fi

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -29,9 +29,10 @@ do
   esac
 done
 
-if test -z ${yarn_lock_file}
+if ! test -f ${yarn_lock_file}
 then
-  echo "Please use \`\`-f'' option to specify location of 'yarn.lock' file."
+  echo "Please use \`\`-f'' option to specify location of existing" \
+      "'yarn.lock' file."
   echo "'${0} -h' for more information."
   exit 1
 fi
@@ -57,6 +58,8 @@ then
 s/^ *resolved \{1,\}\"\(.\{1,\}\/\(.\{1,\}\)#.\{1,\}\)\"$/\
 fetch -o ${download_prefix}\2 \1/p" ${yarn_lock_file} | /bin/sh -s
 else
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
   sed -n -e "/^ *resolved /s/^ *resolved \+\"\(.\+\)\"$/\1/p" \
       ${yarn_lock_file} | wget -P ${download_prefix} -v -i -
 fi


### PR DESCRIPTION
This PR improves scripts which may be used for upgrading offline
host managed by the ``pacman'' package manager.

- [x] FreeBSD and sh(1) compatible.

See also: commit a531ae25ebe440050f3f6e945cc6ff4dd7857762, 612f8ce357e28c59823a5bb2c09ffcac07d9479b, 2851f22581376d4a2a85f0a27c29cbacf6d1acac.

