### PR TITLE
Download FreeBSD articles and books

### DIFF
--- a/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
@@ -29,20 +29,33 @@ do
   esac
 done
 
-if test -z ${download_prefix}
+if test -z "${download_prefix}"
 then
   echo "Please use \`\`-p'' option to specify download (target) location."
   echo "'${0} -h' for more information."
   exit 1
-elif test -n ${tag}
+elif test -n "${tag}"
 then
-  # We have to use extended (modern) regular expressions and not BRE, because we
-  # need branches, and BRE does not have it (``|'').
-  download_prefix=$(echo "${download_prefix}" | sed -n -E \
-      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+  if test 1 -lt ${#download_prefix}
+  then
+    # We have to use extended (modern) regular expressions and not BRE, because
+    # we need branches, and BRE does not have it (``|'').
+    download_prefix=$(echo "${download_prefix}" | sed -n -E \
+        -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+  else
+    if test "/" != ${download_prefix}
+    then
+      download_prefix=${download_prefix}/${tag}
+    else
+      download_prefix=${download_prefix}${tag}
+    fi
+  fi
 fi
-download_prefix=$(echo "${download_prefix}" | sed -n -E \
-    -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+if test 1 -lt ${#download_prefix}
+then
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+fi
 
 if ! test -e ${download_prefix}
 then

--- a/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
@@ -29,20 +29,33 @@ do
   esac
 done
 
-if test -z ${download_prefix}
+if test -z "${download_prefix}"
 then
   echo "Please use \`\`-p'' option to specify download (target) location."
   echo "'${0} -h' for more information."
   exit 1
-elif test -n ${tag}
+elif test -n "${tag}"
 then
-  # We have to use extended (modern) regular expressions and not BRE, because we
-  # need branches, and BRE does not have it (``|'').
-  download_prefix=$(echo "${download_prefix}" | sed -n -E \
-      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+  if test 1 -lt ${#download_prefix}
+  then
+    # We have to use extended (modern) regular expressions and not BRE, because
+    # we need branches, and BRE does not have it (``|'').
+    download_prefix=$(echo "${download_prefix}" | sed -n -E \
+        -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2\/${tag}/p")
+  else
+    if test "/" != ${download_prefix}
+    then
+      download_prefix=${download_prefix}/${tag}
+    else
+      download_prefix=${download_prefix}${tag}
+    fi
+  fi
 fi
-download_prefix=$(echo "${download_prefix}" | sed -n -E \
-    -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+if test 1 -lt ${#download_prefix}
+then
+  download_prefix=$(echo "${download_prefix}" | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+fi
 
 if ! test -e ${download_prefix}
 then

--- a/FreeBSD/info/README.md
+++ b/FreeBSD/info/README.md
@@ -1,0 +1,21 @@
+# Download documentation about FreeBSD
+
+## Description
+
+\`\`dinfo.sh'' script downloads books and articles from the FreeBSD
+Download site (from its "en" part†) in PDF format.
+
+## Usage
+
+```sh
+./dinfo.sh -p <download location>
+```
+
+or, for script synopsis:
+
+```sh
+./dinfo.sh -h
+```
+
+† The script downloads documentation it finds on this page:
+https://download.freebsd.org/ftp/doc/en/

--- a/FreeBSD/info/dinfo.sh
+++ b/FreeBSD/info/dinfo.sh
@@ -1,0 +1,100 @@
+#! /bin/sh
+# Copyright (c) 2018, Ruslan Garipov.
+# Contacts: <ruslanngaripov@gmail.com>.
+# License: MIT License (https://opensource.org/licenses/MIT).
+# Author: Ruslan Garipov <ruslanngaripov@gmail.com>.
+
+PrintUsage()
+{
+  echo "Usage: dinfo.sh [-p <download location>]"
+  echo "                [-h]"
+  exit 0;
+}
+
+index_page=https://download.freebsd.org/ftp/doc/en/
+format=pdf
+
+CreateTheFirstLayout()
+{
+  local download_prefix_1=${download_prefix}
+  local index_page_1=${index_page}
+  local chapters_1=$(${fetch} -o - ${index_page} 2>/dev/null | \
+sed -n -e "s/.\{1,\}<td>\
+<a href=\"\(.\{1,\}\)\" title=\".\{1,\}\">.\{1,\}<\/a><\/td>.\{1,\}/\1/p")
+  for chapter_1 in ${chapters_1}
+  {
+    download_prefix=$(echo ${download_prefix_1}/${chapter_1} | sed -n -E \
+        -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+    if ! test -e ${download_prefix}
+    then
+      mkdir ${download_prefix}
+    fi
+    index_page=${index_page_1}${chapter_1}
+    book=$(echo ${chapter_1} | sed -n -e "s/\([a-z]\{1,\}\)s\//\1.${format}/p")
+    CreateTheSecondLayout
+  }
+}
+CreateTheSecondLayout()
+{
+  local download_prefix_2=${download_prefix}
+  local index_page_2=${index_page}
+  local chapters_2=$(${fetch} -o - ${index_page} 2>/dev/null | \
+sed -n -e "s/.\{1,\}<td>\
+<a href=\"\(.\{1,\}\)\" title=\".\{1,\}\">.\{1,\}<\/a><\/td>.\{1,\}/\1/p")
+  for chapter_2 in ${chapters_2}
+  {
+    download_prefix=$(echo ${download_prefix_2}/${chapter_2} | sed -n -E \
+        -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+    if ! test -e ${download_prefix}
+    then
+      mkdir ${download_prefix}
+    fi
+    index_page=${index_page_2}${chapter_2}
+    DownloadBook
+  }
+}
+DownloadBook()
+{
+  ${fetch} -o ${download_prefix}/${book} ${index_page}${book}
+}
+
+if test 0 -eq $#
+then
+  PrintUsage
+fi
+while getopts ":hp:" opt
+do
+  case ${opt} in
+    h) PrintUsage;;
+    p) download_prefix=${OPTARG};;
+    \?) echo "\`\`${OPTARG}'' is an unknown option." 1>&2
+      exit 1;;
+    :) echo "\`\`${OPTARG}'' requires an argument." 1>&2
+      exit 1;;
+  esac
+done
+
+if test -z ${download_prefix}
+then
+  echo "Please use \`\`-p'' option to specify download (target) location."
+  echo "'${0} -h' for more information."
+  exit 1
+fi
+if test 1 -lt ${#download_prefix}
+then
+  download_prefix=$(echo ${download_prefix} | sed -n -E \
+      -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
+fi
+
+if ! test -e ${download_prefix}
+then
+  mkdir -p ${download_prefix}
+fi
+
+if test "$(fetch 2>&1 | grep -e 'usage')"
+then
+  fetch=fetch
+else
+  fetch=curl
+fi
+CreateTheFirstLayout

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -29,14 +29,14 @@ do
   esac
 done
 
-if ! test -f ${yarn_lock_file}
+if ! test -f "${yarn_lock_file}"
 then
   echo "Please use \`\`-f'' option to specify location of existing" \
       "'yarn.lock' file."
   echo "'${0} -h' for more information."
   exit 1
 fi
-if test -z ${download_prefix}
+if test -z "${download_prefix}"
 then
   echo "Please use \`\`-p'' option to specify download (target) location."
   echo "'${0} -h' for more information."


### PR DESCRIPTION
This patch adds new script (\`\`dinfo.sh'') and fixes some existing ones.

New \`\`dinfo.sh'' script downloads FreeBSD documentation from the [FreeBSD Download site][1] duplicating its structure. Currently in PDF format only.

ChangeLog:

* Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh: Fix processing of undefined strings. Fix processing of *download location* set to \`\`.''.
* Arch_Linux/Offline_Upgrade/download_databases_msys2.sh: Likewise.
* Arch_Linux/Offline_Upgrade/download_packages.sh: Likewise.
* FreeBSD/info/README.md: New file.
* FreeBSD/info/dinfo.sh: Likewise.
* JavaScript/Yarn/download_dependencies.sh: Fix processing of undefined strings.

[1]: https://download.freebsd.org/ftp/doc/en/