### PR TITLE
Fix negation expressions specified at `test(1)`

### DIFF
--- a/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_arch_linux.sh
@@ -57,7 +57,7 @@ then
       -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
 fi
 
-if ! test -e ${download_prefix}
+if test ! -e ${download_prefix}
 then
   mkdir -p ${download_prefix}
 fi

--- a/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
+++ b/Arch_Linux/Offline_Upgrade/download_databases_msys2.sh
@@ -57,7 +57,7 @@ then
       -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
 fi
 
-if ! test -e ${download_prefix}
+if test ! -e ${download_prefix}
 then
   mkdir -p ${download_prefix}
 fi

--- a/Arch_Linux/Offline_Upgrade/download_packages.sh
+++ b/Arch_Linux/Offline_Upgrade/download_packages.sh
@@ -31,7 +31,7 @@ do
   esac
 done
 
-if ! test -f "${package_list_file}"
+if test ! -f "${package_list_file}"
 then
   echo "Please use \`\`-f'' option to specify location of existing package" \
       "list file."
@@ -66,7 +66,7 @@ then
       -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
 fi
 
-if ! test -e ${download_prefix}
+if test ! -e ${download_prefix}
 then
   mkdir -p ${download_prefix}
 fi

--- a/FreeBSD/info/dinfo.sh
+++ b/FreeBSD/info/dinfo.sh
@@ -25,7 +25,7 @@ sed -n -e "s/.\{1,\}<td>\
   {
     download_prefix=$(echo ${download_prefix_1}/${chapter_1} | sed -n -E \
         -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
-    if ! test -e ${download_prefix}
+    if test ! -e ${download_prefix}
     then
       mkdir ${download_prefix}
     fi
@@ -45,7 +45,7 @@ sed -n -e "s/.\{1,\}<td>\
   {
     download_prefix=$(echo ${download_prefix_2}/${chapter_2} | sed -n -E \
         -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
-    if ! test -e ${download_prefix}
+    if test ! -e ${download_prefix}
     then
       mkdir ${download_prefix}
     fi
@@ -86,7 +86,7 @@ then
       -e "s/^(.{1,})([^\/])\/{0,1}$/\1\2/p")
 fi
 
-if ! test -e ${download_prefix}
+if test ! -e ${download_prefix}
 then
   mkdir -p ${download_prefix}
 fi

--- a/JavaScript/Yarn/download_dependencies.sh
+++ b/JavaScript/Yarn/download_dependencies.sh
@@ -29,7 +29,7 @@ do
   esac
 done
 
-if ! test -f "${yarn_lock_file}"
+if test ! -f "${yarn_lock_file}"
 then
   echo "Please use \`\`-f'' option to specify location of existing" \
       "'yarn.lock' file."
@@ -43,7 +43,7 @@ then
   exit 1
 fi
 
-if ! test -e ${download_prefix}
+if test ! -e ${download_prefix}
 then
   mkdir -p ${download_prefix}
 fi


### PR DESCRIPTION
There are some previous commits which introduced incorrect usage of
`! expression` within `test(1)` commands, sorry.  Revision Serg-Norseman@09529d4 fixes that.

--

I just added another commit Serg-Norseman@4122a48.  It introduces new command line option `-z` in the \`\`dinfo.sh'' script.  This option creates compressed tarballs within the target directory (specified with `-p` option) -- one tarball per each first level chapter in the documentation storage.

-- :smiling_imp: